### PR TITLE
Fixed bibliography not respected when set in dir-locals

### DIFF
--- a/company-bibtex.el
+++ b/company-bibtex.el
@@ -92,15 +92,15 @@
 (defun company-bibtex-candidates (prefix)
   "Parse .bib file for candidates and return list of keys.
 Prepend the appropriate part of PREFIX to each item."
-  (with-temp-buffer
-    (mapc #'insert-file-contents
-          (if (listp company-bibtex-bibliography)
-              company-bibtex-bibliography
-            (list company-bibtex-bibliography)))
-    (let ((prefixprefix (company-bibtex-get-candidate-citation-style prefix)))
-      (progn (mapcar (function (lambda (l) (concat prefixprefix l)))
-                             (mapcar (function (lambda (x) (company-bibtex-build-candidate x)))
-                                     (company-bibtex-parse-bibliography)))))))
+  (let ((bib-paths (if (listp company-bibtex-bibliography)
+                      company-bibtex-bibliography
+                    (list company-bibtex-bibliography))))
+    (with-temp-buffer
+      (mapc #'insert-file-contents bib-paths)
+      (let ((prefixprefix (company-bibtex-get-candidate-citation-style prefix)))
+        (progn (mapcar (function (lambda (l) (concat prefixprefix l)))
+                       (mapcar (function (lambda (x) (company-bibtex-build-candidate x)))
+                               (company-bibtex-parse-bibliography))))))))
 
 (defun company-bibtex-get-candidate-citation-style (candidate)
   "Get prefix for CANDIDATE."


### PR DESCRIPTION
`company-bibtex-bibliography` was not respected when set in file- or
dir-locals. Because `with-temp-buffer` would open another buffer that
would not have the locals of the current file,
`company-bibtex-bibliography` would not be present in such a case.

However, it is desirable to configure bibtex-paths in
dir-locals (e.g. on a per-project basis).

This fixes this behaviour by pulling `company-bibtex-bibliography` out
into a variable before calling `with-temp-buffer`.