### PR TITLE
Remove regexp-opt from dependency list

### DIFF
--- a/company-bibtex.el
+++ b/company-bibtex.el
@@ -4,7 +4,7 @@
 
 ;; Author: GB Gardner <gbgar@users.noreply.github.com>
 ;; Version: 1.0
-;; Package-Requires: ((company "0.9.0") (cl-lib "0.5") (parsebib "1.0") (regexp-opt))
+;; Package-Requires: ((company "0.9.0") (cl-lib "0.5") (parsebib "1.0"))
 ;; Keywords: company-mode, bibtex
 ;; URL: https://github.com/gbgar/company-bibtex
 


### PR DESCRIPTION
Because regexp-opt is a standard package.